### PR TITLE
Fix message encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,13 +22,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cargo-action-fmt"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
  "serde",
  "serde_json",
- "urlencoding",
 ]
 
 [[package]]
@@ -208,12 +207,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "urlencoding"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-action-fmt"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/olix0r/cargo-action-fmt"
@@ -12,7 +12,6 @@ Converts cargo check (and clippy) JSON output to the GitHub Action error format
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-urlencoding = "2.1"
 
 [dependencies.clap]
 version = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ fn main() -> Result<()> {
             ClippyObj::BuildScriptExecuted(_) => {}
             ClippyObj::CompilerMessage { message } => {
                 if message.code.is_some() {
+                    let msg = encode_newlines(message.rendered);
                     for span in message.spans.into_iter() {
                         println!(
                             "::{} file={},line={},endLine={},col={},endColumn={}::{}",
@@ -68,7 +69,7 @@ fn main() -> Result<()> {
                             span.line_end,
                             span.column_start,
                             span.column_end,
-                            urlencoding::encode(&*message.rendered),
+                            msg,
                         );
                     }
                 }
@@ -82,4 +83,8 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn encode_newlines(orig: String) -> String {
+    orig.replace('\n', "%0A")
 }


### PR DESCRIPTION
Fully urlencoded messages do not render properly; so this change removes
teh `urlencoding` dependency and, instead, manually replaces newline
characters with "%0A" to escape newlines.