### PR TITLE
Show version in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cargo-action-fmt"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-action-fmt"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/olix0r/cargo-action-fmt"
@@ -16,4 +16,4 @@ serde_json = "1"
 [dependencies.clap]
 version = "3"
 default-features = false
-features = ["cargo", "derive", "std"]
+features = ["derive", "std"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 /// Converts cargo check (and clippy) JSON output to the GitHub Action error format
 #[derive(Debug, Parser)]
+#[clap(version)]
 struct Args {
     path: Option<PathBuf>,
 }


### PR DESCRIPTION
This change updates --help output to include a version and adds a
`--version` flag.