### PR TITLE
ci: Add dependency auditing workflows

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,0 +1,42 @@
+# Audits dependencies with cargo-deny
+name: deps
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - Cargo.lock
+      - deny.toml
+      - .github/workflows/deps.yml
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  # Check for security advisories.
+  #
+  # Failures are not fatal, since issues are opened in the linkerd2 repo via rustsecbot.
+  advisories:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+    - uses: EmbarkStudios/cargo-deny-action@4340bbf5bc9e7034fae7c4857e9ab87cab35c905
+      with:
+        command: check advisories
+
+  # Audit licenses, unreleased crates, and unexpected duplicate versions.
+  bans:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+    - uses: EmbarkStudios/cargo-deny-action@4340bbf5bc9e7034fae7c4857e9ab87cab35c905
+      with:
+        command: check bans licenses sources

--- a/.github/workflows/rustsec.yml
+++ b/.github/workflows/rustsec.yml
@@ -1,0 +1,27 @@
+name: rustsec
+
+on:
+
+  # Run when the Cargo.lock changes or when this workflow changes.
+  push:
+    branches:
+      - main
+    paths:
+      - Cargo.lock
+      - deny.toml
+      - .github/workflows/rustsec.yml
+
+  # Run at 00:00 UTC every day
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    name: audit
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - uses: olix0r/rustsecbot@560c817c7a019e1f0c2318721b55156409be7f8c


### PR DESCRIPTION
This change adds a _rustsec_ workflow that uses rustsecbot to create
issues for rustsec issues and a _deps_ workflow that uses `cargo-deny`
to flag dependency issues in PRs.